### PR TITLE
Updated docroot location to be in standard location

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 
   4. Enjoy.
 
+## Configuration
+* Get into the box: `vagrant ssh`
+* Project location: `/var/www/drupal8/docroot`
+
 ## More info
 
 This is an implementation of [Acquia Vagrant](https://github.com/thom8/acquia-vagrant) so please refer to this project for more info.

--- a/config.yml
+++ b/config.yml
@@ -17,7 +17,7 @@ vagrantup_provision: no
 # You can use NFS by switching the 'type' to 'nfs'.
 vagrant_synced_folders:
   - local_path: .
-    destination: /drupal
+    destination: /var/www/drupal8
     id: drupal
     type: nfs
 
@@ -47,7 +47,7 @@ firewall_allowed_tcp_ports:
 apache_listen_port: 80
 apache_vhosts:
   - servername: "d8.local"
-    documentroot: "/drupal/docroot"
+    documentroot: "/var/www/drupal8/docroot"
 
 # PHP config
 php_version: "5.5"

--- a/reset-full.sh
+++ b/reset-full.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Reset Drupal installation and vagrant box.
+#
 
-vagrant ssh -c "sudo chmod 775 /drupal/docroot/sites/default && rm -rf /home/vagrant/vagrantup /home/vagrant/siteinstalled /drupal/docroot"
+vagrant ssh -c "sudo chmod 775 /var/www/drupal/docroot/sites/default && rm -rf /home/vagrant/vagrantup /home/vagrant/siteinstalled /var/www/drupal/docroot"
 vagrant provision

--- a/reset.sh
+++ b/reset.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+#
+# Re-install Drupal.
+#
 
 vagrant ssh -c "sudo rm -rf /home/vagrant/vagrantup /home/vagrant/siteinstalled"
 vagrant provision


### PR DESCRIPTION
The usual location for all web data in *nix systems is `/var/www/<projectname>`, so I've moved drupal to be under `/var/www/drupal8`
